### PR TITLE
heavy_deflector_giant.vmt

### DIFF
--- a/leaderboard_class_heavy_deflector_giant.vmt
+++ b/leaderboard_class_heavy_deflector_giant.vmt
@@ -1,0 +1,10 @@
+"UnlitGeneric"
+{
+	"$baseTexture" "hud/leaderboard_class_heavy_deflector"
+	"$vertexcolor" 1
+	"$no_fullbright" 1
+	"$ignorez" 1
+	"%keywords" "tf"
+	"$translucent" 1
+}
+


### PR DESCRIPTION
Used in robot_giant_yoovy_2024.pop, templates in his missions. Stock VTF.